### PR TITLE
remove atomic transaction from besluit create

### DIFF
--- a/src/brc/api/viewsets.py
+++ b/src/brc/api/viewsets.py
@@ -1,15 +1,9 @@
-from django.shortcuts import get_object_or_404
-
 from rest_framework import viewsets
-from rest_framework.reverse import reverse
 from vng_api_common.audittrails.viewsets import (
     AuditTrailViewSet, AuditTrailViewsetMixin
 )
-from vng_api_common.notifications.kanalen import Kanaal
 from vng_api_common.notifications.viewsets import NotificationViewSetMixin
-from vng_api_common.permissions import permission_class_factory
-from vng_api_common.utils import lookup_kwargs_to_filters
-from vng_api_common.viewsets import CheckQueryParamsMixin, NestedViewSetMixin
+from vng_api_common.viewsets import CheckQueryParamsMixin
 
 from brc.datamodel.models import Besluit, BesluitInformatieObject
 
@@ -18,8 +12,7 @@ from .data_filtering import ListFilterByAuthorizationsMixin
 from .filters import BesluitFilter, BesluitInformatieObjectFilter
 from .kanalen import KANAAL_BESLUITEN
 from .permissions import (
-    BesluitAuthScopesRequired, BesluitBaseAuthRequired,
-    BesluitRelatedAuthScopesRequired
+    BesluitAuthScopesRequired, BesluitRelatedAuthScopesRequired
 )
 from .scopes import (
     SCOPE_BESLUITEN_AANMAKEN, SCOPE_BESLUITEN_ALLES_LEZEN,

--- a/src/brc/sync/signals.py
+++ b/src/brc/sync/signals.py
@@ -89,8 +89,6 @@ def sync_delete_bio(relation: BesluitInformatieObject):
 
 
 def sync_create_besluit(besluit: Besluit):
-    if besluit.zaak == '':
-        return
 
     # build the URL of the besluit
     path = reverse('besluit-detail', kwargs={
@@ -129,9 +127,6 @@ def sync_create_besluit(besluit: Besluit):
 
 
 def sync_delete_besluit(besluit: Besluit):
-    if besluit.zaak == '':
-        return
-
     client = Client.from_url(besluit._zaakbesluit)
     client.auth = APICredential.get_auth(besluit._zaakbesluit)
     try:
@@ -153,7 +148,7 @@ def sync_informatieobject_relation(sender, instance: BesluitInformatieObject=Non
 @receiver([post_save, post_delete], sender=Besluit)
 def sync_besluit(sender, instance: Besluit = None, **kwargs):
     signal = kwargs['signal']
-    if signal is post_save and kwargs.get('created', False):
+    if signal is post_save and instance.zaak and not instance._zaakbesluit:
         sync_create_besluit(instance)
-    elif signal is post_delete:
+    elif signal is post_delete and instance._zaakbesluit:
         sync_delete_besluit(instance)

--- a/src/brc/tests/test_sync_besluit.py
+++ b/src/brc/tests/test_sync_besluit.py
@@ -41,7 +41,7 @@ class BesluitSyncCreateTests(BesluitSyncMixin, JWTAuthMixin, APITestCase):
         self.mocked_sync_create_besluit.assert_called_with(besluit)
 
     def test_delete_sync_besluit(self):
-        besluit = BesluitFactory.create()
+        besluit = BesluitFactory.create(_zaakbesluit='https://example.com/zrc/zaakbesluittype/abcd')
         url = get_operation_url('besluit_read', uuid=besluit.uuid)
 
         response = self.client.delete(url)


### PR DESCRIPTION
**Changes:**
1. Refactor `create` of `BesluitSerializer` for removing atomic property
1. Change conditions of invoking `sync_create_besluit` and `sync_delete_besluit`