### PR TITLE
Feature/notificatie documentatie header for new vng api common

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -60,4 +60,4 @@ sqlparse==0.3.0           # via django
 unidecode==1.0.22         # via vng-api-common
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.3           # via requests
-vng-api-common==1.0.6
+vng-api-common==1.0.7

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -73,5 +73,5 @@ text-unidecode==1.2       # via faker
 unidecode==1.0.22
 uritemplate==3.0.0
 urllib3==1.24.3
-vng-api-common==1.0.6
+vng-api-common==1.0.7
 wrapt==1.10.11            # via astroid

--- a/src/brc/api/schema.py
+++ b/src/brc/api/schema.py
@@ -34,6 +34,8 @@ Deze API vereist autorisatie. Je kan de
 [token-tool](https://zaken-auth.vng.cloud/) gebruiken om JWT-tokens te
 genereren.
 
+### Notificaties
+
 {notification_documentation(KANAAL_BESLUITEN)}
 
 **Handige links**


### PR DESCRIPTION
because I removed the header `Notificaties` from the util in `vng-api-common` version 1.0.7