### PR TITLE
Bump vng_api_common to 1.3.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -63,4 +63,4 @@ sqlparse==0.3.0           # via django
 unidecode==1.0.22         # via vng-api-common
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.3           # via requests
-vng-api-common==1.3.1
+vng-api-common==1.3.2

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -76,5 +76,5 @@ text-unidecode==1.2       # via faker
 unidecode==1.0.22
 uritemplate==3.0.0
 urllib3==1.24.3
-vng-api-common==1.3.1
+vng-api-common==1.3.2
 wrapt==1.10.11            # via astroid


### PR DESCRIPTION
to ensure that https://github.com/VNG-Realisatie/vng-api-common/commit/4ba4b66ec83d5ec3fd55c2c3561f2d5b8f51addf fixes the issues with deleting objects after GET requests